### PR TITLE
chore(autoscaling): allow configuration of autoscaling policies

### DIFF
--- a/.changes/unreleased/Added-20250310-125734.yaml
+++ b/.changes/unreleased/Added-20250310-125734.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Allow configuring AutoScaling policies
+time: 2025-03-10T12:57:34.751109+01:00


### PR DESCRIPTION
This commit adds the ability to configure autoscaling policies for the ECS service. The module now accepts a list of objects, each representing a policy.

By default, the module creates a policy that scales based on the average CPU utilization of the ECS service. The target value is set to 70% (old behavior).